### PR TITLE
Fixed the texture decode path so it no longer hard-crashes on GPU OOM…

### DIFF
--- a/trellis2/pipelines/trellis2_image_to_3d.py
+++ b/trellis2/pipelines/trellis2_image_to_3d.py
@@ -447,8 +447,10 @@ class Trellis2ImageTo3DPipeline(Pipeline):
             List[SparseTensor]: The decoded texture voxels
         """
         decoder = self._load_model('tex_slat_decoder')
+        decoder.low_vram = not self.keep_model_loaded
         ret = decoder(slat, guide_subs=subs) * 0.5 + 0.5
         self._unload_model('tex_slat_decoder')
+        decoder.low_vram = False
         return ret
     
     @torch.no_grad()


### PR DESCRIPTION
Fixed the texture decode path so it no longer hard-crashes on GPU OOM during tex_slat_decoder:

trellis2_image_to_3d.py:decode_tex_slat now sets decoder.low_vram = not self.keep_model_loaded (matching the shape decoder path).
sparse_unet_vae.py now makes SparseUnetVaeDecoder.low_vram actually do something by propagating to submodules, and SparseConvNeXtBlock3d runs its MLP in smaller chunks (and automatically falls back to chunking if a CUDA OOM happens).