### PR TITLE
Add crop_margin and shape_rescale_t flow-matching parameters

### DIFF
--- a/nodes/nodes_inference.py
+++ b/nodes/nodes_inference.py
@@ -27,6 +27,9 @@ Parameters:
 - model_config: The loaded TRELLIS.2 config
 - image: Input image (RGB)
 - mask: Foreground mask (white=object, black=background)
+- background_color: Color of background to fill (black, gray, or white)
+- crop_margin: Padding ratio around the segmented object before DinoV3 extraction (0.1 = 10%).
+
 Use any background removal node (BiRefNet, rembg, etc.) to generate the mask.""",
             inputs=[
                 io.Custom("TRELLIS2_MODEL_CONFIG").Input("model_config"),
@@ -34,6 +37,8 @@ Use any background removal node (BiRefNet, rembg, etc.) to generate the mask."""
                 io.Mask.Input("mask"),
                 io.Combo.Input("background_color", options=["black", "gray", "white"],
                                default="black", optional=True),
+                io.Float.Input("crop_margin", default=0.1, min=0.0, max=0.5, step=0.01, optional=True,
+                               tooltip="Padding ratio around the segmented object before DinoV3 extraction (0.1 = 10%)."),
             ],
             outputs=[
                 io.Custom("TRELLIS2_CONDITIONING").Output(display_name="conditioning"),
@@ -42,7 +47,7 @@ Use any background removal node (BiRefNet, rembg, etc.) to generate the mask."""
         )
 
     @classmethod
-    def execute(cls, model_config, image, mask, background_color="black"):
+    def execute(cls, model_config, image, mask, background_color="black", crop_margin=0.1):
         # All heavy imports happen inside subprocess
         from .stages import run_conditioning
 
@@ -58,6 +63,7 @@ Use any background removal node (BiRefNet, rembg, etc.) to generate the mask."""
             mask=mask,
             include_1024=include_1024,
             background_color=background_color,
+            crop_margin=crop_margin,
         )
 
         return io.NodeOutput(conditioning, preprocessed_image)
@@ -99,6 +105,8 @@ Returns mesh, shape_slat (for texture generation), and subs (subdivision guides)
                 # VRAM Control
                 io.Int.Input("max_tokens", default=49152, min=16384, max=262144, step=4096, optional=True,
                              tooltip="Max tokens for 1024 cascade. Lower = less VRAM but potentially lower quality. Default 49152 (~9GB), try 32768 (~7GB) or 24576 (~6GB) for lower VRAM."),
+                io.Float.Input("shape_rescale_t", default=3.0, min=0.0, max=10.0, step=0.1, optional=True,
+                               tooltip="Shape generation flow-matching time rescaling parameter (rescale_t). Higher values spend more sampler steps on fine details, creating sharper geometry."),
             ],
             outputs=[
                 io.Custom("TRIMESH").Output(display_name="mesh"),
@@ -120,6 +128,7 @@ Returns mesh, shape_slat (for texture generation), and subs (subdivision guides)
         shape_guidance_rescale=0.05,
         shape_sampling_steps=12,
         max_tokens=49152,
+        shape_rescale_t=3.0,
     ):
         import numpy as np
         import trimesh as Trimesh
@@ -140,6 +149,7 @@ Returns mesh, shape_slat (for texture generation), and subs (subdivision guides)
                 shape_guidance_rescale=shape_guidance_rescale,
                 shape_sampling_steps=shape_sampling_steps,
                 max_num_tokens=max_tokens,
+                shape_rescale_t=shape_rescale_t,
             )
 
         # TRIMESH stays in internal Z-up (conversion to Y-up happens only at export)
@@ -180,6 +190,8 @@ Takes shape_slat and subs from "Image to Shape" and generates PBR materials
                                tooltip="Texture guidance rescale. Reduces artifacts from high CFG"),
                 io.Int.Input("tex_sampling_steps", default=12, min=1, max=50, step=1, optional=True,
                              tooltip="Texture sampling steps. More steps = better quality but slower"),
+                io.Float.Input("tex_rescale_t", default=3.0, min=1.0, max=6.0, step=0.1, optional=True,
+                               tooltip="Time-rescaling parameter for the texture flow sampler (Microsoft default: 3.0)."),
             ],
             outputs=[
                 io.Custom("TRELLIS2_VOXELGRID").Output(display_name="voxelgrid"),
@@ -197,6 +209,7 @@ Takes shape_slat and subs from "Image to Shape" and generates PBR materials
         tex_guidance_strength=3.0,
         tex_guidance_rescale=0.20,
         tex_sampling_steps=12,
+        tex_rescale_t=3.0,
     ):
         from .stages import run_texture_generation
 
@@ -213,6 +226,7 @@ Takes shape_slat and subs from "Image to Shape" and generates PBR materials
                 tex_guidance_strength=tex_guidance_strength,
                 tex_guidance_rescale=tex_guidance_rescale,
                 tex_sampling_steps=tex_sampling_steps,
+                tex_rescale_t=tex_rescale_t,
             )
 
         return io.NodeOutput(voxelgrid)
@@ -462,6 +476,8 @@ Parameters:
                                tooltip="Texture guidance rescale. Reduces artifacts from high CFG"),
                 io.Int.Input("tex_sampling_steps", default=12, min=1, max=50, step=1, optional=True,
                              tooltip="Texture sampling steps"),
+                io.Float.Input("tex_rescale_t", default=3.0, min=0.0, max=10.0, step=0.1, optional=True,
+                               tooltip="Texture flow-matching time rescaling parameter (rescale_t). Higher values spend more sampler steps on fine details, creating sharper textures."),
             ],
             outputs=[
                 io.Custom("TRELLIS2_VOXELGRID").Output(display_name="voxelgrid"),
@@ -478,6 +494,7 @@ Parameters:
         tex_guidance_strength=3.0,
         tex_guidance_rescale=0.20,
         tex_sampling_steps=12,
+        tex_rescale_t=3.0,
     ):
         import torch
         from .stages import run_texture_mesh
@@ -493,6 +510,7 @@ Parameters:
                 tex_guidance_strength=tex_guidance_strength,
                 tex_guidance_rescale=tex_guidance_rescale,
                 tex_sampling_steps=tex_sampling_steps,
+                tex_rescale_t=tex_rescale_t,
             )
 
         return io.NodeOutput(voxelgrid)
@@ -718,6 +736,8 @@ views participate in blending.""",
                                tooltip="Softmax temperature for view blending. Higher = sharper transitions between views."),
                 io.Combo.Input("background_color", options=["black", "gray", "white"], default="black", optional=True,
                                tooltip="Background color for masked regions"),
+                io.Float.Input("shape_rescale_t", default=3.0, min=0.0, max=10.0, step=0.1, optional=True,
+                               tooltip="Shape generation flow-matching time rescaling parameter (rescale_t). Higher values spend more sampler steps on fine details, creating sharper geometry."),
             ],
             outputs=[
                 io.Custom("TRIMESH").Output(display_name="mesh"),
@@ -748,6 +768,7 @@ views participate in blending.""",
         front_axis='z',
         blend_temperature=2.0,
         background_color="black",
+        shape_rescale_t=3.0,
     ):
         import numpy as np
         import torch
@@ -802,6 +823,7 @@ views participate in blending.""",
                 max_num_tokens=max_tokens,
                 front_axis=front_axis,
                 blend_temperature=blend_temperature,
+                shape_rescale_t=shape_rescale_t,
             )
 
         # TRIMESH stays in internal Z-up (conversion to Y-up happens only at export)

--- a/nodes/stages.py
+++ b/nodes/stages.py
@@ -749,6 +749,7 @@ def run_conditioning(
     mask: torch.Tensor,
     include_1024: bool = True,
     background_color: str = "black",
+    crop_margin: float = 0.1,
 ) -> Tuple[Dict[str, torch.Tensor], torch.Tensor]:
     """
     Run DinoV3 conditioning extraction.
@@ -787,6 +788,8 @@ def run_conditioning(
 
     # Process mask - handle various input formats and ensure 2D grayscale
     mask_np = mask.cpu().numpy()
+    if mask_np.max() > 1.0:
+        mask_np = mask_np / 255.0
 
     # Handle 4D [B, H, W, C] format (e.g., IMAGE passed as MASK)
     if mask_np.ndim == 4:
@@ -825,7 +828,7 @@ def run_conditioning(
     pil_image = Image.fromarray(rgba, 'RGBA')
 
     # Smart crop
-    pil_image = smart_crop_square(pil_image, alpha_np, margin_ratio=0.1, background_color=bg_color)
+    pil_image = smart_crop_square(pil_image, alpha_np, margin_ratio=crop_margin, background_color=bg_color)
 
     # Load (or reuse cached) DinoV3 via ComfyUI ModelPatcher
     comfy.model_management.throw_exception_if_processing_interrupted()
@@ -878,6 +881,7 @@ def run_shape_generation(
     shape_guidance_rescale: float = 0.05,
     shape_sampling_steps: int = 12,
     max_num_tokens: int = 49152,
+    shape_rescale_t: float = 3.0,
 ) -> Dict[str, Any]:
     """
     Run shape generation.
@@ -889,6 +893,7 @@ def run_shape_generation(
         ss_*: Sparse structure sampling params
         shape_*: Shape latent sampling params
         max_num_tokens: Max tokens for 1024 cascade (lower = less VRAM)
+        shape_rescale_t: Flow matching time rescaling parameter
 
     Returns:
         Tuple of (mesh_vertices, mesh_faces, shape_slat_data, subs_data)
@@ -921,6 +926,7 @@ def run_shape_generation(
         "steps": shape_sampling_steps,
         "guidance_strength": shape_guidance_strength,
         "guidance_rescale": shape_guidance_rescale,
+        "rescale_t": shape_rescale_t,
     }
 
     torch.manual_seed(seed)
@@ -1201,6 +1207,7 @@ def run_multiview_shape_generation(
     max_num_tokens: int = 49152,
     front_axis: str = 'z',
     blend_temperature: float = 2.0,
+    shape_rescale_t: float = 3.0,
 ) -> Dict[str, Any]:
     """
     Multi-view shape generation.
@@ -1245,6 +1252,7 @@ def run_multiview_shape_generation(
         "steps": shape_sampling_steps,
         "guidance_strength": shape_guidance_strength,
         "guidance_rescale": shape_guidance_rescale,
+        "rescale_t": shape_rescale_t,
     }
 
     torch.manual_seed(seed)
@@ -1360,6 +1368,7 @@ def run_texture_generation(
     tex_guidance_strength: float = 3.0,
     tex_guidance_rescale: float = 0.20,
     tex_sampling_steps: int = 12,
+    tex_rescale_t: float = 3.0,
 ) -> Dict[str, Any]:
     """
     Run texture generation.
@@ -1414,6 +1423,7 @@ def run_texture_generation(
         "steps": tex_sampling_steps,
         "guidance_strength": tex_guidance_strength,
         "guidance_rescale": tex_guidance_rescale,
+        "rescale_t": tex_rescale_t,
     }
 
     torch.manual_seed(seed)
@@ -1522,6 +1532,7 @@ def run_texture_mesh(
     tex_guidance_strength: float = 3.0,
     tex_guidance_rescale: float = 0.20,
     tex_sampling_steps: int = 12,
+    tex_rescale_t: float = 3.0,
 ) -> Dict[str, Any]:
     """
     Generate PBR textures for an existing mesh using its encoded shape latent.
@@ -1537,6 +1548,7 @@ def run_texture_mesh(
         seed: Random seed
         tex_guidance_strength: Texture CFG scale
         tex_sampling_steps: Texture sampling steps
+        tex_rescale_t: Flow matching time rescaling parameter
 
     Returns:
         Dict with voxel data for NPZ export (same format as run_texture_generation)
@@ -1579,6 +1591,7 @@ def run_texture_mesh(
         "steps": tex_sampling_steps,
         "guidance_strength": tex_guidance_strength,
         "guidance_rescale": tex_guidance_rescale,
+        "rescale_t": tex_rescale_t,
     }
 
     torch.manual_seed(seed)


### PR DESCRIPTION
**Grayscale Mask Normalization Guard:**
   - Added a safe normalization guard to mask_np to handle mask tensors that exceed a max value of `1.0` (on-the-fly dividing by `255.0` when necessary). This prevents downstream tensor issues depending on how the input mask was generated.
   
**Adjustable DinoV3 `crop_margin`:**
   - Exposed the `crop_margin` parameter (default `0.1`) inside DinoV3 conditioning. Gives users fine-grained control over the bounding box margin during the smart square crop, resolving issues where tight crops cut off object edges or loose crops diluted focus.
   
**Flow Matching Time Rescaling (`rescale_t`):**
   - Exposed the `shape_rescale_t` and `tex_rescale_t` flow-matching time-rescaling parameters. This enables advanced users to customize step-spacing.
