### PR TITLE
feat(export): emit three_model UI entry so /history surfaces exported files

### DIFF
--- a/nodes/nodes_unwrap.py
+++ b/nodes/nodes_unwrap.py
@@ -1352,7 +1352,18 @@ Takes the voxelgrid_npz_path from "Shape to Textured Mesh" and:
         gc.collect()
         comfy.model_management.soft_empty_cache()
 
-        return io.NodeOutput(output_path)
+        # Emit three_model UI entry so downstream consumers (the production
+        # character pipeline's _extract_three_model_glb) can locate the file
+        # via ComfyUI's /history endpoint. Without this, the workflow output
+        # dict is empty and the orchestrator can't fetch the result.
+        return io.NodeOutput(
+            output_path,
+            ui={"three_model": [{
+                "filename": filename,
+                "subfolder": "",
+                "type": "output",
+            }]},
+        )
 
 
 class Trellis2ExportTrimesh(io.ComfyNode):
@@ -1414,7 +1425,18 @@ Supports: GLB, OBJ, PLY, STL, 3MF, DAE""",
 
         logger.info(f"Exported to: {output_path}")
 
-        return io.NodeOutput(str(output_path))
+        # Emit three_model UI entry so downstream consumers (the production
+        # character pipeline's _extract_three_model_glb) can locate the file
+        # via ComfyUI's /history endpoint. Without this, the workflow output
+        # dict is empty and the orchestrator can't fetch the result.
+        return io.NodeOutput(
+            str(output_path),
+            ui={"three_model": [{
+                "filename": filename,
+                "subfolder": "",
+                "type": "output",
+            }]},
+        )
 
 
 NODE_CLASS_MAPPINGS = {


### PR DESCRIPTION
## Problem

`Trellis2ExportGLB` and `Trellis2ExportTrimesh` return only a `file_path` STRING:

```python
return io.NodeOutput(output_path)
```

STRING returns are passed to downstream nodes inside the workflow graph, but ComfyUI's `/history` endpoint does not surface them in the `outputs` section without an explicit `ui` dict on `NodeOutput`.

This breaks external HTTP orchestrators that poll `/history` to discover produced files: the workflow completes successfully and the GLB is written to `output/`, but the outputs dict appears empty — leaving the orchestrator with no way to locate the result file (it would have to glob the filesystem, losing the `prompt_id` → filename binding).

## Fix

Pass `ui={"three_model": [...]}` to `NodeOutput`, matching the convention used by ComfyUI-3D-Pack and other 3D-emitting node packs (same shape as `SaveImage`'s `ui={"images": [...]}`):

```python
return io.NodeOutput(
    output_path,
    ui={"three_model": [{
        "filename": filename,
        "subfolder": "",
        "type": "output",
    }]},
)
```

The entry includes `filename`, `subfolder`, and `type` so consumers can construct the file URL via the standard `/api/view` endpoint.

## Verification

End-to-end run of the full image-to-GLB pipeline:

```
LoadImage → LoadTrellis2Models → GetConditioning → Trellis2ImageToShape
→ Trellis2ShapeToTexturedMesh → Trellis2Simplify → Trellis2UVUnwrap
→ Trellis2RasterizePBR → Trellis2ExportTrimesh
```

- **Before:** `/history` returns `{"status": "success", "outputs": {}}` for the Export node.
- **After:** `/history` returns `{"...": {"outputs": {"<node_id>": {"three_model": [{"filename": "trellis2_00001.glb", "subfolder": "", "type": "output"}]}}}}`.

Produced a 21 MB textured GLB (299k verts / 191k faces), accessible at `/api/view?filename=trellis2_00001.glb&type=output`.

## Notes

- The `three_model` key matches the ComfyUI-3D-Pack convention. Open to renaming if you prefer a different key (e.g. `mesh` or `gltf`).
- Both `Trellis2ExportGLB` and `Trellis2ExportTrimesh` are patched (identical change).
- No behavioural change for in-ComfyUI workflows — downstream nodes still receive the STRING via the regular output binding.
